### PR TITLE
feat: added functionality to customize prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +403,41 @@ checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -504,6 +563,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -792,6 +861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +887,63 @@ name = "linux-raw-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
+name = "liquid"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f68ae1011499ae2ef879f631891f21c78e309755f4a5e483c4a8f12e10b609"
+dependencies = [
+ "doc-comment",
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "liquid-core"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e0724dfcaad5cfb7965ea0f178ca0870b8d7315178f4a7179f5696f7f04d5f"
+dependencies = [
+ "anymap2",
+ "itertools",
+ "kstring",
+ "liquid-derive",
+ "num-traits",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "liquid-derive"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2fb41a9bb4257a3803154bdf7e2df7d45197d1941c9b1a90ad815231630721"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "liquid-lib"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a17e273a6fb1fb6268f7a5867ddfd0bd4683c7e19b51084f3d567fad4348c0"
+dependencies = [
+ "itertools",
+ "liquid-core",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "time",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "lock_api"
@@ -889,6 +1025,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +1075,7 @@ dependencies = [
  "bytes",
  "clap",
  "figment",
+ "liquid",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -1099,6 +1242,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
+name = "pest"
+version = "2.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1327,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1447,6 +1641,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1703,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1574,6 +1785,37 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1881,6 +2123,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "uncased"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +2148,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "urlencoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ opentelemetry_sdk = { version = "0.21.1", features = ["rt-tokio", "logs"] }
 opentelemetry-otlp = { version = "0.14.0", features = ["tonic", "metrics", "logs"]  }
 opentelemetry-semantic-conventions = { version = "0.13.0" }
 axum-tracing-opentelemetry = "0.16.0"
+liquid = "0.26.4"
 
 [build-dependencies]
 anyhow = "1.0.75"

--- a/example/history_template.liquid
+++ b/example/history_template.liquid
@@ -1,0 +1,4 @@
+{% for item in items -%}
+{{ item.identity }}{% if item.name %} {{ item.name }}{% endif %}: {{ item.content }}
+{% endfor -%}
+ASSISTANT:

--- a/example/history_template_custom_roles.liquid
+++ b/example/history_template_custom_roles.liquid
@@ -1,0 +1,16 @@
+{% for item in items -%}
+{%- capture identity -%}
+    {%- case item.identity -%}
+        {%- when "System", "Tool" -%}
+            Robot
+        {%- when "User" -%}
+            Customer
+        {%- when "Assistant" -%}
+            Support
+        {%- else -%}
+    {%- endcase -%}
+{%- endcapture -%}
+
+{{- identity }}{% if item.name %} {{ item.name }}{% endif %}: {{ item.content }}
+{% endfor -%}
+ASSISTANT:

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,4 +17,14 @@ pub struct Config {
     #[arg(long, short)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub otlp_endpoint: Option<String>,
+
+    /// Template for converting OpenAI message history to prompt
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history_template: Option<String>,
+
+    /// File containing the history template string
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history_template_file: Option<String>
 }

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,0 +1,182 @@
+use std::fs::File;
+use std::io::Read;
+use std::sync::Arc;
+use anyhow::bail;
+use liquid::{ParserBuilder, Template};
+use serde::Serialize;
+use crate::routes::chat::ChatCompletionMessageParams;
+
+const DEFAULT_TEMPLATE: &str =
+"{% for item in items %}\
+{{ item.identity }}{% if item.name %} {{ item.name }}{% endif %}: {{ item.content }}
+{% endfor %}\
+ASSISTANT:";
+
+#[derive(Clone)]
+pub struct HistoryBuilder {
+    history_template: Arc<Template>
+}
+
+impl HistoryBuilder {
+    pub fn new(template: &Option<String>, template_file: &Option<String>) -> anyhow::Result<Self> {
+        if template.is_some() && template_file.is_some() {
+            bail!("cannot set both history-template and history-template-file")
+        }
+        let mut _ref_holder = None;
+
+
+        let template = match template_file {
+            None => match template {
+                None => {DEFAULT_TEMPLATE}
+                Some(cfg) => {cfg.as_str()}
+            }
+            Some(filename) => {
+                _ref_holder = Some(load_template_file(filename)?);
+                _ref_holder.as_ref().unwrap().as_str()
+            }
+        };
+
+        let history_template = Arc::new(ParserBuilder::with_stdlib().build()?.parse(template)?);
+
+        Ok(HistoryBuilder {history_template})
+    }
+
+    pub fn build_history(&self, messages: &Vec<ChatCompletionMessageParams>) -> anyhow::Result<String> {
+        let items: Vec<_> = messages.iter().map(|x| HistoryItem::new(x)).collect();
+        let context = liquid::object!({"items": items});
+        Ok(self.history_template.render(&context)?)
+    }
+}
+
+fn load_template_file(file: &String) -> anyhow::Result<String> {
+    let mut file = File::open(file)?;
+    let mut result = String::new();
+    file.read_to_string(&mut result)?;
+    Ok(result)
+}
+
+#[derive(Serialize)]
+struct HistoryItem {
+    identity: String,
+    content: String,
+    name: Option<String>
+}
+
+impl HistoryItem {
+    pub fn new(message: &ChatCompletionMessageParams) -> Self {
+        let (identity, content, name) = match message {
+            ChatCompletionMessageParams::System { content, name } => { ("System".into(), content.clone(), name.clone()) }
+            ChatCompletionMessageParams::User { content, name } => { ("User".into(), content.clone(), name.clone()) }
+            ChatCompletionMessageParams::Assistant { content } => { ("Assistant".into(), content.clone(), None) }
+            ChatCompletionMessageParams::Tool { content, .. } => { ("Tool".into(), content.clone(), None) }
+        };
+
+        HistoryItem { identity, content, name }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    pub fn test_default_template() {
+        let template = None;
+        let template_file = None;
+        let builder = HistoryBuilder::new(&template, &template_file).expect("default template should build correctly");
+
+        let messages = vec![
+            ChatCompletionMessageParams::System {content: "test system 1".into(), name: Some("system 1".into())},
+            ChatCompletionMessageParams::System {content: "test system 2".into(), name: None},
+            ChatCompletionMessageParams::Assistant {content: "test assistant 1".into()},
+            ChatCompletionMessageParams::Tool {content: "test tool 1".into(), tool_call_id: "tool_1".into()},
+            ChatCompletionMessageParams::User {content: "test user 1".into(), name: Some("user 1".into())},
+            ChatCompletionMessageParams::User {content: "test user 2".into(), name: None}
+        ];
+
+        let result = builder.build_history(&messages).expect("history should build correctly");
+
+        let expected_result: String =
+"System system 1: test system 1
+System: test system 2
+Assistant: test assistant 1
+Tool: test tool 1
+User user 1: test user 1
+User: test user 2
+ASSISTANT:".into();
+
+        assert_eq!(expected_result, result)
+
+    }
+
+    #[test]
+    pub fn test_template_file() {
+        let template = None;
+        let template_file = Some(format!("{}/example/history_template.liquid", env!("CARGO_MANIFEST_DIR")));
+        let builder = HistoryBuilder::new(&template, &template_file).expect("default template should build correctly");
+
+        let messages = vec![
+            ChatCompletionMessageParams::System {content: "test system 1".into(), name: Some("system 1".into())},
+            ChatCompletionMessageParams::System {content: "test system 2".into(), name: None},
+            ChatCompletionMessageParams::Assistant {content: "test assistant 1".into()},
+            ChatCompletionMessageParams::Tool {content: "test tool 1".into(), tool_call_id: "tool_1".into()},
+            ChatCompletionMessageParams::User {content: "test user 1".into(), name: Some("user 1".into())},
+            ChatCompletionMessageParams::User {content: "test user 2".into(), name: None}
+        ];
+
+        let result = builder.build_history(&messages).expect("history should build correctly");
+
+        let expected_result: String =
+            "System system 1: test system 1
+System: test system 2
+Assistant: test assistant 1
+Tool: test tool 1
+User user 1: test user 1
+User: test user 2
+ASSISTANT:".into();
+
+        assert_eq!(expected_result, result)
+
+    }
+
+    #[test]
+    pub fn test_template_file_custom_roles() {
+        let template = None;
+        let template_file = Some(format!("{}/example/history_template_custom_roles.liquid", env!("CARGO_MANIFEST_DIR")));
+        let builder = HistoryBuilder::new(&template, &template_file).expect("default template should build correctly");
+
+        let messages = vec![
+            ChatCompletionMessageParams::System {content: "test system 1".into(), name: Some("system 1".into())},
+            ChatCompletionMessageParams::System {content: "test system 2".into(), name: None},
+            ChatCompletionMessageParams::Assistant {content: "test assistant 1".into()},
+            ChatCompletionMessageParams::Tool {content: "test tool 1".into(), tool_call_id: "tool_1".into()},
+            ChatCompletionMessageParams::User {content: "test user 1".into(), name: Some("user 1".into())},
+            ChatCompletionMessageParams::User {content: "test user 2".into(), name: None}
+        ];
+
+        let result = builder.build_history(&messages).expect("history should build correctly");
+
+        let expected_result: String =
+            "Robot system 1: test system 1
+Robot: test system 2
+Support: test assistant 1
+Robot: test tool 1
+Customer user 1: test user 1
+Customer: test user 2
+ASSISTANT:".into();
+
+        assert_eq!(expected_result, result)
+
+    }
+
+    #[test]
+    pub fn test_validations() {
+        let template = Some("abc".into());
+        let template_file = Some("abc".into());
+        match HistoryBuilder::new(&template, &template_file) {
+            Ok(_) => {assert!(false, "expected err")}
+            Err(e) => {assert_eq!("cannot set both history-template and history-template-file", e.to_string())}
+        };
+
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod config;
 mod error;
+pub mod history;
 pub mod routes;
 pub mod startup;
+pub mod state;
 pub mod telemetry;
 mod utils;
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,6 +2,6 @@ pub(crate) use chat::compat_chat_completions;
 pub(crate) use completions::compat_completions;
 pub(crate) use health_check::health_check;
 
-mod chat;
+pub(crate) mod chat;
 mod completions;
 mod health_check;

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -4,7 +4,9 @@ use axum::Router;
 use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
 
 use crate::config::Config;
+use crate::history::HistoryBuilder;
 use crate::routes;
+use crate::state::AppState;
 use crate::triton::grpc_inference_service_client::GrpcInferenceServiceClient;
 
 pub async fn run_server(config: Config) -> anyhow::Result<()> {
@@ -13,13 +15,16 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
         .await
         .context("failed to connect triton endpoint")?;
 
+    let history_builder = HistoryBuilder::new(&config.history_template, &config.history_template_file)?;
+    let state = AppState{grpc_client, history_builder};
+
     let app = Router::new()
         .route("/v1/completions", post(routes::compat_completions))
         .route(
             "/v1/chat/completions",
             post(routes::compat_chat_completions),
         )
-        .with_state(grpc_client)
+        .with_state(state)
         .layer(OtelAxumLayer::default())
         .route("/health_check", get(routes::health_check));
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,9 @@
+use tonic::transport::Channel;
+use crate::history::HistoryBuilder;
+use crate::triton::grpc_inference_service_client::GrpcInferenceServiceClient;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub grpc_client: GrpcInferenceServiceClient<Channel>,
+    pub history_builder: HistoryBuilder
+}


### PR DESCRIPTION
This PR adds support for customizing the prompt to allow for different prompt styles for different LLMs.

This is done with a [liquid](https://crates.io/crates/liquid) template ([syntax docs here](https://shopify.github.io/liquid/basics/introduction/)). This was chosen for execution speed and flexibility. Two new flags were added to support this - `--history-template` and `--history-template-file`. The first takes the template as a raw string on the CLI, and the second takes a path containing the template. This functionality defaults to the pre-existing prompt format. 